### PR TITLE
Add/26 wp query get posts

### DIFF
--- a/60-query-optimization/README.md
+++ b/60-query-optimization/README.md
@@ -151,14 +151,14 @@ wp_term_relationships.term_taxonomy_id IN (123)
 
 And the posts can be retrieved with:
 
-```
+```php
 /* ✅ This approach is correct. */
 $my_posts = $my_query->posts;
 ```
 
 However, if the following is used by mistake instead of the `posts` property, a second query will fire. This query in addition to adding an unnecessary query, may break the intended query.
 
-```
+```php
 /* ❌ This approach is incorrect. */
 $my_posts = $my_query->get_posts();
 ```


### PR DESCRIPTION
Solves https://github.com/Automattic/sample-code-vip/issues/26

Add example of how accidentally using `$my_query->get_posts();` can result in poor performance.

The extra query in the example on a vanilla install locally was an extra 0.0005 seconds. We've seen this issue cause an unnecessary 2s query on larger sites.

I'm not sure if adding to the query optiz README is the best place for this example. I'm open for discussion or suggestions.