### PR TITLE
Improve the JavaScript escaping example

### DIFF
--- a/10-security/README.md
+++ b/10-security/README.md
@@ -72,14 +72,34 @@ That makes the SQL look like `AND $wpdb->posts.post_title LIKE 'foo' || DROP TAB
 When it comes to sending dynamic data from PHP for JavaScript, care must be taken to ensure values are properly escaped. All values should be encoded and possibly decoded using variety of functions.
 
 ```php
+// ..
+// ..
+?>
+
+<!-- ❌Don't do this: -->
 <script type="text/javascript">
-    /* ❌ These approaches are incorrect */
     var name  = '<?php echo $name; ?>';
     var title = '<?php echo esc_js( $title ); ?>';
     var url   = '<?php echo esc_url( $url ); ?>';
     var html  = '<?php echo '<h1>' . $title . '</h1>'; ?>';
     var obj   = <?php echo wp_json_encode( $array ); ?>;
 </script>
+
+<!--  ✅Do this instead: -->
+<script type="text/javascript">
+	var name  = decodeURIComponent( '<?php echo rawurlencode( (string) $name ); ?>' );
+	var title = decodeURIComponent( '<?php echo rawurlencode( (string) $title ); ?>' );
+	var url   = <?php echo wp_json_encode( esc_url( $url ) ) ?>;
+	var html  = document.createElement('h1');
+	html.innerText = title;
+	var obj   = JSON.parse( decodeURIComponent( '<?php
+		echo rawurlencode( wp_json_encode( $array ) );
+	?>' ) );
+</script>
+
+<?php
+// ..
+// ..
 ```
 
 In the snippet above:


### PR DESCRIPTION
Clarifying the "Escaping Dynamic JavaScript Values" example with do's and don't do's. We can still leave the script where it is for people who just want to see the right code, but when showing an example with incorrect code - I think it's better to have the correct code alongside as well.

Also added `<?php` and `?>` with empty comments to enable proper syntax highlighting